### PR TITLE
Add issue markdown files for portfolio-inspired features

### DIFF
--- a/.github/ISSUES/01-profile-page.md
+++ b/.github/ISSUES/01-profile-page.md
@@ -1,0 +1,13 @@
+# Issue: Profile page
+
+**Description**
+
+Add a `Profile`/About section (photo, short bio, location) and a static HTML/CSS page under `static/` or an API endpoint to manage profile data.
+
+**Acceptance criteria**
+
+- New `profile` static page at `static/profile.html` (or API endpoints to read/update profile)
+- Profile photo, name, bio, location fields displayed
+- Basic responsive styling
+
+**Suggested labels:** enhancement, frontend

--- a/.github/ISSUES/02-experience-timeline.md
+++ b/.github/ISSUES/02-experience-timeline.md
@@ -1,0 +1,13 @@
+# Issue: Experience timeline
+
+**Description**
+
+Add an Education/Experience/Internships timeline to showcase institutions, roles, dates and certificate links (downloadable or external links).
+
+**Acceptance criteria**
+
+- Timeline section in the UI (e.g., `static/experience.html` or integrated into main page)
+- Ability to link to external certificate URLs
+- Responsive layout
+
+**Suggested labels:** enhancement, frontend, backend

--- a/.github/ISSUES/03-skills-profiles.md
+++ b/.github/ISSUES/03-skills-profiles.md
@@ -1,0 +1,12 @@
+# Issue: Skills & Profiles
+
+**Description**
+
+Add a Skills/Abilities section with visual proficiency (star ratings) and optional links to coding profiles (HackerRank, CodeChef, LeetCode).
+
+**Acceptance criteria**
+
+- Skills listed with visual rating (stars or bars)
+- Links to external coding profiles configurable via HTML or API
+
+**Suggested labels:** enhancement, frontend

--- a/.github/ISSUES/04-projects-showcase.md
+++ b/.github/ISSUES/04-projects-showcase.md
@@ -1,0 +1,13 @@
+# Issue: Projects showcase
+
+**Description**
+
+Create a Projects gallery with images, descriptions, tech tags, and live/demo links. Include hover animations for visual polish.
+
+**Acceptance criteria**
+
+- Projects section with cards showing image, title, short description, tech tags
+- Each project optionally links to a live demo
+- Hover/animation effects and responsive layout
+
+**Suggested labels:** enhancement, frontend

--- a/.github/ISSUES/05-certifications-page.md
+++ b/.github/ISSUES/05-certifications-page.md
@@ -1,0 +1,12 @@
+# Issue: Certifications page
+
+**Description**
+
+Add a Certifications section listing certificates with links or downloadable files (e.g., Google Drive links).
+
+**Acceptance criteria**
+
+- Certifications listed with title, issuer, date and link
+- Links open externally or download when appropriate
+
+**Suggested labels:** enhancement, frontend, backend

--- a/.github/ISSUES/06-social-contact.md
+++ b/.github/ISSUES/06-social-contact.md
@@ -1,0 +1,12 @@
+# Issue: Social & Contact
+
+**Description**
+
+Add social links (LinkedIn, Twitter), contact email and styled icon buttons (use Font Awesome or similar).
+
+**Acceptance criteria**
+
+- Contact section updated with social icons and email
+- Icons link to external social profiles
+
+**Suggested labels:** enhancement, frontend

--- a/.github/ISSUES/07-ui-ux-enhancements.md
+++ b/.github/ISSUES/07-ui-ux-enhancements.md
@@ -1,0 +1,13 @@
+# Issue: UI/UX enhancements
+
+**Description**
+
+Improve UI: integrate responsive Bootstrap layout, add animations (hover effects), custom fonts, and overall styling improvements.
+
+**Acceptance criteria**
+
+- Updated CSS and layout using Bootstrap (or similar)
+- Animations for project cards and interactive elements
+- Confirm responsiveness across viewports
+
+**Suggested labels:** enhancement, frontend

--- a/.github/ISSUES/08-interests-tools.md
+++ b/.github/ISSUES/08-interests-tools.md
@@ -1,0 +1,12 @@
+# Issue: Interests & Tools
+
+**Description**
+
+Add Interests/Games and Tools sections listing hobbies and tool proficiencies (with years where helpful).
+
+**Acceptance criteria**
+
+- Interests and Tools sections added to the UI
+- Tools list shows familiarity/years
+
+**Suggested labels:** enhancement, frontend

--- a/.github/ISSUES/09-create-github-issues.md
+++ b/.github/ISSUES/09-create-github-issues.md
@@ -1,0 +1,12 @@
+# Task: Create GitHub issues
+
+**Description**
+
+This meta-task tracks creating one GitHub issue per feature above. These files represent proposed issues; open-source maintainers can review and convert them to Issues or merge this PR to add them to the repository as markdown.
+
+**Acceptance criteria**
+
+- One markdown file per feature under `.github/ISSUES/`
+- Pull request created for review
+
+**Suggested labels:** maintenance


### PR DESCRIPTION
This PR adds one markdown file per proposed feature under `.github/ISSUES/` so maintainers can review and convert them to GitHub Issues or merge to keep them tracked in the repo.

Each file corresponds to a feature we discussed (profile, experience, skills, projects, certifications, social/contact, UI/UX improvements, interests/tools) and includes suggested labels and acceptance criteria.